### PR TITLE
fix: remove the requirement of .env from the build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "env-cmd -f .env.development react-scripts start",
-    "build": "env-cmd -f .env.production react-scripts build",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## ✨ 내용
Netfliy build 오류

`Error: Failed to find .env file at path: .env.production
   at getEnvFile (/opt/build/repo/node_modules/env-cmd/dist/get-env-vars.js:40:19)`

를 위한 [해결방안 참고](https://answers.netlify.com/t/failed-to-find-env-file-at-path-env/56639)

## 📸 스크린샷(선택)
