### PR TITLE
chore: remove specified basename

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <Router basename="/sooklion-admin">
+      <Router basename="/">
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route


### PR DESCRIPTION

## ✨ 내용
<!-- 설명을 적어주세요 -->
basename을 특정하면 유저가 직접 URL에 입력해야하는 것이 번거로워서
특정된 `react-router-dom`의 `BrowserRouterProps.basename`을 삭제
